### PR TITLE
Fix heap corruption caused by too small allocation

### DIFF
--- a/pfft/pfft.d
+++ b/pfft/pfft.d
@@ -131,8 +131,9 @@ $(D scale) methods.
  */
     static T[] allocate(size_t n)
     {
-        T* r = cast(T*) alignedMalloc(n, alignment(n));
-        assert(((impl.alignment(n) - 1) & cast(size_t) r) == 0);
+        size_t bytes = n * T.sizeof;
+        T* r = cast(T*) alignedMalloc(bytes, alignment(bytes));
+        assert(((impl.alignment(bytes) - 1) & cast(size_t) r) == 0);
         return r[0..n];
     }
 


### PR DESCRIPTION
I was having trouble running even the simplest programs using pfft, e.g. this code

```d
import pfft.pfft;

void main()
{
    float[] data = Fft!float.allocate(256);
    data[] = 0f;
}
```

would immediately give me

```
*** Error in `./pfft-test': malloc(): memory corruption: 0x000000000264f960 ***
======= Backtrace: =========
/lib/x86_64-linux-gnu/libc.so.6(+0x777e5)[0x7f958bb447e5]
/lib/x86_64-linux-gnu/libc.so.6(+0x8213e)[0x7f958bb4f13e]
/lib/x86_64-linux-gnu/libc.so.6(__libc_calloc+0xba)[0x7f958bb51dca]
```

And so forth. I had a look at what `allocate` was doing, and found that it's allocating N *bytes* for an array of N *elements*, which would explain the error. I'm not sure how this has managed to go unnoticed though. Let me know if I've got it wrong somehow ¯\\\_(ツ)\_/¯